### PR TITLE
Update logic for obtaining set of configurations without Pull Requests

### DIFF
--- a/run.rb
+++ b/run.rb
@@ -40,13 +40,14 @@ Parallel.each(repos, in_threads: 4) do |repo_name|
   refs = client.refs(repo_name)
   has_not_pr_config = config.select { |_name, rc| repo_name =~ /#{rc['repo_pattern']}/ }.select do |name, _rc|
     begin
-      b = refs.find { |r| r[:ref] == "refs/heads/#{branch_name(name)}" }
-      if b && pull_requests.none? { |pr| pr[:title] == pr_title(name) }
-        client.delete_branch(repo_name, branch_name(name))
-        return true
-      else
-        logger.info "rule:#{name} repo:#{repo_name} already create pull request"
-        next
+      if refs.find { |r| r[:ref] == "refs/heads/#{branch_name(name)}" }
+        if pull_requests.none? { |pr| pr[:title] == pr_title(name) }
+          client.delete_branch(repo_name, branch_name(name))
+          return true
+        else
+          logger.info "rule:#{name} repo:#{repo_name} already create pull request"
+          next
+        end
       end
     rescue Octokit::NotFound
     rescue StandardError => e


### PR DESCRIPTION
Hello Pyama-san,

This P/R is a fix about obtaining a set of config where there are no existing Pull Requests.

In the original implementation, if the branch existed and there was no Pull Request, the branch was deleted and added to the set (return true). However, if it did not meet that condition, (e.g. If the branch does not exist) it would skip the loop and treat as "a Pull Request already exists", causing the config to not be included in the set even if it was a configuration without an existing Pull Request.

After fix, we first check for the existence of the branch, and then divide the processing based on the presence or absence of an existing Pull Request.